### PR TITLE
Add support for using Gval's variable selectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/PaesslerAG/jsonpath
 
-require github.com/PaesslerAG/gval v1.0.1
+require (
+	github.com/PaesslerAG/gval v1.0.1
+	github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a
+)
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/PaesslerAG/jsonpath
 
-require github.com/PaesslerAG/gval v1
+require github.com/PaesslerAG/gval v1.0.1
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
 github.com/PaesslerAG/gval v0.1.0 h1:XxyoMWvLhTNiRcXg2dsG0LaOMcRTh22doPMWYLAe528=
 github.com/PaesslerAG/gval v0.1.0/go.mod h1:jjpVgM2F5GvUIHLM66Z4B4tyojnCW8kh/QY68RpHucQ=
+github.com/PaesslerAG/gval v1.0.1 h1:QnCvok0w0Y3uZNxmNmC6GZ0cuBl+jH0tu/rBMT8pso4=
+github.com/PaesslerAG/gval v1.0.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/PaesslerAG/gval v0.1.0 h1:XxyoMWvLhTNiRcXg2dsG0LaOMcRTh22doPMWYLAe528=
-github.com/PaesslerAG/gval v0.1.0/go.mod h1:jjpVgM2F5GvUIHLM66Z4B4tyojnCW8kh/QY68RpHucQ=
+github.com/PaesslerAG/gval v0.1.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/gval v1.0.1 h1:QnCvok0w0Y3uZNxmNmC6GZ0cuBl+jH0tu/rBMT8pso4=
 github.com/PaesslerAG/gval v1.0.1/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a h1:J8FuFJ7K+Hiwkla2kT9fVIVix+EZhAlDsZwRlfFI3MA=
+github.com/generikvault/gvalstrings v0.0.0-20180926130504-471f38f0112a/go.mod h1:ms6iGk40n2YQrbM9Sr6onzwYBD1q5D0T5DQmcaye6uU=

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -35,6 +35,7 @@ var lang = gval.NewLanguage(
 	gval.Base(),
 	gval.PrefixExtension('$', parseRootPath),
 	gval.PrefixExtension('@', parseCurrentPath),
+	gval.VariableSelector(VariableSelector()),
 )
 
 //Language is the JSONPath Language

--- a/parse.go
+++ b/parse.go
@@ -11,29 +11,35 @@ import (
 
 // Parse parses the complete JSON path starting from the given parser location.
 // You can use it with, for example, gval.PrefixExtension.
-func Parse(ctx context.Context, p *gval.Parser) (gval.Evaluable, error) {
-	return parseRootPath(ctx, p)
+func Parse(ctx context.Context, p *gval.Parser, opts ...Option) (gval.Evaluable, error) {
+	return parseRootPath(opts)(ctx, p)
 }
 
 type parser struct {
 	*gval.Parser
-	vg   variableGetter
-	path path
+	path *path
 }
 
-func parseRootPath(ctx context.Context, gParser *gval.Parser) (r gval.Evaluable, err error) {
-	p := newParser(gParser)
-	return p.parse(ctx)
+func parseRootPath(opts []Option) func(ctx context.Context, gParser *gval.Parser) (r gval.Evaluable, err error) {
+	return func(ctx context.Context, gParser *gval.Parser) (r gval.Evaluable, err error) {
+		p := newParser(gParser, rootElement, opts)
+		return p.parse(ctx)
+	}
 }
 
-func parseCurrentPath(ctx context.Context, gParser *gval.Parser) (r gval.Evaluable, err error) {
-	p := newParser(gParser)
-	p.appendPlainSelector(currentElementSelector())
-	return p.parse(ctx)
+func parseCurrentPath(opts []Option) func(ctx context.Context, gParser *gval.Parser) (r gval.Evaluable, err error) {
+	return func(ctx context.Context, gParser *gval.Parser) (r gval.Evaluable, err error) {
+		p := newParser(gParser, currentElement, opts)
+		return p.parse(ctx)
+	}
 }
 
-func newParser(p *gval.Parser) *parser {
-	return &parser{Parser: p, vg: variableGetter{p}, path: plainPath{}}
+func newParser(gp *gval.Parser, root gval.Evaluable, opts []Option) *parser {
+	p := &parser{Parser: gp, path: &path{root: root, mode: selectorKeepErrors}}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
 }
 
 func (p *parser) parse(c context.Context) (r gval.Evaluable, err error) {
@@ -50,33 +56,7 @@ func (p *parser) parsePath(c context.Context) error {
 	case '.':
 		return p.parseSelect(c)
 	case '[':
-		keys, seperator, err := p.parseBracket(c)
-
-		if err != nil {
-			return err
-		}
-
-		switch seperator {
-		case ':':
-			if len(keys) > 3 {
-				return fmt.Errorf("range query has at least the parameter [min:max:step]")
-			}
-			keys = append(keys, []gval.Evaluable{
-				p.Const(0), p.Const(float64(math.MaxInt32)), p.Const(1)}[len(keys):]...)
-			p.appendAmbiguousSelector(rangeSelector(p.vg, keys[0], keys[1], keys[2]))
-		case '?':
-			if len(keys) != 1 {
-				return fmt.Errorf("filter needs exactly one key")
-			}
-			p.appendAmbiguousSelector(filterSelector(p.vg, keys[0]))
-		default:
-			if len(keys) == 1 {
-				p.appendPlainSelector(directSelector(p.vg, keys[0]))
-			} else {
-				p.appendAmbiguousSelector(multiSelector(p.vg, keys))
-			}
-		}
-		return p.parsePath(c)
+		return p.parseBracket(c, false)
 	case '(':
 		return p.parseScript(c)
 	default:
@@ -89,20 +69,74 @@ func (p *parser) parseSelect(c context.Context) error {
 	scan := p.Scan()
 	switch scan {
 	case scanner.Ident:
-		p.appendPlainSelector(directSelector(p.vg, p.Const(p.TokenText())))
+		p.appendSelector(directSelector(varSelector(p.variableChild(p.Const(p.TokenText())))), selectorKeepErrors)
 		return p.parsePath(c)
 	case '.':
-		p.appendAmbiguousSelector(mapperSelector(p.vg))
+		p.appendSelector(varSelector(p.variableRecursiveDescent()), selectorDropErrors)
 		return p.parseMapper(c)
 	case '*':
-		p.appendAmbiguousSelector(starSelector(p.vg))
+		p.appendSelector(varSelector(p.variableWildcard()), selectorDropErrors)
 		return p.parsePath(c)
 	default:
 		return p.Expected("JSON select", scanner.Ident, '.', '*')
 	}
 }
 
-func (p *parser) parseBracket(c context.Context) (keys []gval.Evaluable, seperator rune, err error) {
+func (p *parser) parseMapper(c context.Context) error {
+	scan := p.Scan()
+	switch scan {
+	case scanner.Ident:
+		p.appendSelector(directSelector(varSelector(p.variableChild(p.Const(p.TokenText())))), selectorKeepErrors)
+	case '[':
+		return p.parseBracket(c, true)
+	case '*':
+		p.appendSelector(varSelector(p.variableWildcard()), selectorDropErrors)
+	case '(':
+		return p.parseScript(c)
+	default:
+		p.Camouflage("JSON mapper", '[', scanner.Ident, '*', '(')
+	}
+	return p.parsePath(c)
+}
+
+func (p *parser) parseBracket(c context.Context, mapper bool) error {
+	keys, seperator, err := p.scanBracket(c)
+	if err != nil {
+		return err
+	}
+
+	switch seperator {
+	case ':':
+		if mapper {
+			return fmt.Errorf("mapper can not be combined with range query")
+		} else if len(keys) > 3 {
+			return fmt.Errorf("range query has at least the parameter [min:max:step]")
+		}
+		keys = append(keys, []gval.Evaluable{p.Const(0), p.Const(float64(math.MaxInt32)), p.Const(1)}[len(keys):]...)
+		p.appendSelector(varSelector(p.variableRange(keys[0], keys[1], keys[2])), selectorDropErrors)
+	case '?':
+		if len(keys) != 1 {
+			return fmt.Errorf("filter needs exactly one key")
+		}
+		p.appendSelector(filterSelector(varSelector(p.variableWildcard()), keys[0]), selectorDropErrors)
+	case '*':
+		p.appendSelector(varSelector(p.variableWildcard()), selectorDropErrors)
+	case ',':
+		selectors := make([]selector, len(keys))
+		for i, key := range keys {
+			selectors[i] = varSelector(p.variableChild(key))
+		}
+		p.appendSelector(multiSelector(selectors), selectorDropErrors)
+	default:
+		if len(keys) != 1 {
+			return fmt.Errorf("unexpected separator %q", seperator)
+		}
+		p.appendSelector(varSelector(p.variableChild(keys[0])), selectorKeepErrors)
+	}
+	return p.parsePath(c)
+}
+
+func (p *parser) scanBracket(c context.Context) (keys []gval.Evaluable, seperator rune, err error) {
 	for {
 		scan := p.Scan()
 		skipScan := false
@@ -120,7 +154,7 @@ func (p *parser) parseBracket(c context.Context) (keys []gval.Evaluable, seperat
 			if p.Scan() != ']' {
 				return nil, 0, p.Expected("JSON bracket star", ']')
 			}
-			return []gval.Evaluable{}, 0, nil
+			return nil, '*', nil
 		case ']':
 			if seperator == ':' {
 				skipScan = true
@@ -158,54 +192,58 @@ func (p *parser) parseBracket(c context.Context) (keys []gval.Evaluable, seperat
 	}
 }
 
-func (p *parser) parseMapper(c context.Context) error {
-	scan := p.Scan()
-	switch scan {
-	case scanner.Ident:
-		p.appendPlainSelector(directSelector(p.vg, p.Const(p.TokenText())))
-	case '[':
-		keys, seperator, err := p.parseBracket(c)
-
-		if err != nil {
-			return err
-		}
-		switch seperator {
-		case ':':
-			return fmt.Errorf("mapper can not be combined with range query")
-		case '?':
-			if len(keys) != 1 {
-				return fmt.Errorf("filter needs exactly one key")
-			}
-			p.appendAmbiguousSelector(filterSelector(p.vg, keys[0]))
-		default:
-			p.appendAmbiguousSelector(multiSelector(p.vg, keys))
-		}
-	case '*':
-		p.appendAmbiguousSelector(starSelector(p.vg))
-	case '(':
-		return p.parseScript(c)
-	default:
-		return p.Expected("JSON mapper", '[', scanner.Ident, '*')
-	}
-	return p.parsePath(c)
-}
-
 func (p *parser) parseScript(c context.Context) error {
 	script, err := p.ParseExpression(c)
 	if err != nil {
 		return err
 	}
 	if p.Scan() != ')' {
-		return p.Expected("jsnopath script", ')')
+		return p.Expected("JSONPath script", ')')
 	}
-	p.appendPlainSelector(newScript(script))
+	p.appendSelector(scriptSelector(script), selectorKeepErrors)
 	return p.parsePath(c)
 }
 
-func (p *parser) appendPlainSelector(next plainSelector) {
-	p.path = p.path.withPlainSelector(next)
+func (p *parser) variableWildcard() gval.Evaluable {
+	return p.Var(p.Const(variableWildcard{}))
 }
 
-func (p *parser) appendAmbiguousSelector(next ambiguousSelector) {
-	p.path = p.path.withAmbiguousSelector(next)
+func (p *parser) variableRecursiveDescent() gval.Evaluable {
+	return p.Var(p.Const(variableRecursiveDescent{}))
+}
+
+func (p *parser) variableRange(min, max, step gval.Evaluable) gval.Evaluable {
+	return p.Var(func(c context.Context, v interface{}) (interface{}, error) {
+		min, err := min.EvalInt(c, v)
+		if err != nil {
+			return nil, err
+		}
+
+		max, err := max.EvalInt(c, v)
+		if err != nil {
+			return nil, err
+		}
+
+		step, err := step.EvalInt(c, v)
+		if err != nil {
+			return nil, err
+		}
+
+		return variableRange{Min: min, Max: max, Step: step}, nil
+	})
+}
+
+func (p *parser) variableChild(key gval.Evaluable) gval.Evaluable {
+	return p.Var(func(c context.Context, v interface{}) (interface{}, error) {
+		key, err := key(c, v)
+		if err != nil {
+			return nil, err
+		}
+
+		return variableChild{Key: key}, nil
+	})
+}
+
+func (p *parser) appendSelector(next selector, mode selectorMode) {
+	p.path.appendSelector(next, mode)
 }

--- a/parse.go
+++ b/parse.go
@@ -9,6 +9,12 @@ import (
 	"github.com/PaesslerAG/gval"
 )
 
+// Parse parses the complete JSON path starting from the given parser location.
+// You can use it with, for example, gval.PrefixExtension.
+func Parse(ctx context.Context, p *gval.Parser) (gval.Evaluable, error) {
+	return parseRootPath(ctx, p)
+}
+
 type parser struct {
 	*gval.Parser
 	vg   variableGetter

--- a/selector.go
+++ b/selector.go
@@ -3,209 +3,107 @@ package jsonpath
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/PaesslerAG/gval"
 )
 
-//plainSelector evaluate exactly one result
-type plainSelector func(c context.Context, r, v interface{}) (interface{}, error)
+type selector func(context.Context, interface{}) (values, error)
 
-//ambiguousSelector evaluate wildcard
-type ambiguousSelector func(c context.Context, r, v interface{}, match ambiguousMatcher)
+type currentElementContextKey struct{}
+
+//$
+func rootElement(c context.Context, v interface{}) (interface{}, error) {
+	return v, nil
+}
 
 //@
-func currentElementSelector() plainSelector {
-	return func(c context.Context, r, v interface{}) (interface{}, error) {
-		return c.Value(currentElement{}), nil
-	}
+func currentElement(c context.Context, _ interface{}) (interface{}, error) {
+	return c.Value(currentElementContextKey{}), nil
 }
-
-type currentElement struct{}
 
 func currentContext(c context.Context, v interface{}) context.Context {
-	return context.WithValue(c, currentElement{}, v)
+	return context.WithValue(c, currentElementContextKey{}, v)
 }
 
-//.x, [x]
-func directSelector(gv variableGetter, key gval.Evaluable) plainSelector {
-	return func(c context.Context, r, v interface{}) (interface{}, error) {
-		e, _, err := selectValue(c, gv, key, r, v)
+func varSelector(variable gval.Evaluable) selector {
+	return func(c context.Context, v interface{}) (values, error) {
+		r, err := variable(currentContext(c, v), v)
 		if err != nil {
 			return nil, err
 		}
 
-		return e, nil
+		vs, ok := r.(values)
+		if !ok {
+			return nil, fmt.Errorf("expected path variable to return values, but got %T", r)
+		}
+
+		return vs, nil
 	}
 }
 
-// * / [*]
-func starSelector(gv variableGetter) ambiguousSelector {
-	return func(c context.Context, r, v interface{}, match ambiguousMatcher) {
-		visitAll(c, gv, v, func(key string, val interface{}) { match(key, val) })
+//.
+func directSelector(sel selector) selector {
+	// This selector just drops the wildcard from the resulting values since
+	// it's known to be a direct path.
+	return func(c context.Context, v interface{}) (values, error) {
+		vs, err := sel(c, v)
+		if err != nil {
+			return nil, err
+		}
+
+		return vs.flatMap(func(v value) (values, error) {
+			v.wildcards = nil
+			return v, nil
+		})
 	}
 }
 
 // [x, ...]
-func multiSelector(gv variableGetter, keys []gval.Evaluable) ambiguousSelector {
-	if len(keys) == 0 {
-		return starSelector(gv)
-	}
-	return func(c context.Context, r, v interface{}, match ambiguousMatcher) {
-		for _, k := range keys {
-			e, wildcard, err := selectValue(c, gv, k, r, v)
+func multiSelector(sels []selector) selector {
+	return func(c context.Context, v interface{}) (values, error) {
+		var vs values = valueSlice{}
+		for _, sel := range sels {
+			r, err := sel(c, v)
 			if err != nil {
-				continue
-			}
-			match(wildcard, e)
-		}
-	}
-}
-
-func selectValue(c context.Context, gv variableGetter, key gval.Evaluable, r, v interface{}) (value interface{}, jkey string, err error) {
-	c = currentContext(c, v)
-
-	ki, err := key.EvalString(c, r)
-	if err != nil {
-		return nil, "", fmt.Errorf("could not select value, invalid key: %s", err)
-	}
-
-	vi, err := gv.ForEvaluables(c, gval.Evaluables{key}, v)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return vi, ki, nil
-}
-
-//..
-func mapperSelector(gv variableGetter) (mapper ambiguousSelector) {
-	mapper = func(c context.Context, r, v interface{}, match ambiguousMatcher) {
-		match([]interface{}{}, v)
-		visitAll(c, gv, v, func(wildcard string, v interface{}) {
-			mapper(c, r, v, func(key interface{}, v interface{}) {
-				match(append([]interface{}{wildcard}, key.([]interface{})...), v)
-			})
-		})
-	}
-	return
-}
-
-func visitAll(c context.Context, gv variableGetter, v interface{}, visit func(key string, v interface{})) {
-	switch v := v.(type) {
-	case []interface{}:
-		for i := range v {
-			e, err := gv.ForConst(c, []interface{}{i}, v)
-			if err != nil {
+				// An individual selector failing in a multi-select should not
+				// propagate (only if the number of selectors > 1).
 				continue
 			}
 
-			k := strconv.Itoa(i)
-			visit(k, e)
+			r.concat(&vs)
 		}
-	case map[string]interface{}:
-		for k := range v {
-			e, err := gv.ForConst(c, []interface{}{k}, v)
-			if err != nil {
-				continue
-			}
-
-			visit(k, e)
-		}
+		return vs, nil
 	}
 }
 
 //[? ]
-func filterSelector(gv variableGetter, filter gval.Evaluable) ambiguousSelector {
-	return func(c context.Context, r, v interface{}, match ambiguousMatcher) {
-		visitAll(c, gv, v, func(wildcard string, v interface{}) {
-			condition, err := filter.EvalBool(currentContext(c, v), r)
-			if err != nil {
-				return
+func filterSelector(sel selector, filter gval.Evaluable) selector {
+	return func(c context.Context, v interface{}) (values, error) {
+		r, err := sel(c, v)
+		if err != nil {
+			return nil, err
+		}
+
+		return r.flatMap(func(v value) (values, error) {
+			cond, err := filter.EvalBool(currentContext(c, v.value), v)
+			if err != nil || !cond {
+				// Again, errors don't propagate here.
+				return nil, nil
 			}
-			if condition {
-				match(wildcard, v)
-			}
+
+			return v, nil
 		})
 	}
 }
 
-//[::]
-func rangeSelector(gv variableGetter, min, max, step gval.Evaluable) ambiguousSelector {
-	return func(c context.Context, r, v interface{}, match ambiguousMatcher) {
-		c = currentContext(c, v)
-
-		min, err := min.EvalInt(c, r)
+//(
+func scriptSelector(script gval.Evaluable) selector {
+	return func(c context.Context, v interface{}) (values, error) {
+		v, err := script(currentContext(c, v), v)
 		if err != nil {
-			return
-		}
-		max, err := max.EvalInt(c, r)
-		if err != nil {
-			return
-		}
-		step, err := step.EvalInt(c, r)
-		if err != nil {
-			return
+			return nil, err
 		}
 
-		if min > max {
-			return
-		}
-
-		switch vt := v.(type) {
-		case []interface{}:
-			n := len(vt)
-			min = negmax(min, n)
-			max = negmax(max, n)
-		case map[string]interface{}:
-			// Ranging over a map is explicitly not supported.
-			return
-		default:
-			// Otherwise we hope the variable selector can do its job.
-		}
-
-		if step == 0 {
-			step = 1
-		}
-
-		if step > 0 {
-			for i := min; i < max; i += step {
-				e, err := gv.ForConst(c, []interface{}{i}, v)
-				if err != nil {
-					continue
-				}
-
-				match(strconv.Itoa(i), e)
-			}
-		} else {
-			for i := max - 1; i >= min; i += step {
-				e, err := gv.ForConst(c, []interface{}{i}, v)
-				if err != nil {
-					continue
-				}
-
-				match(strconv.Itoa(i), e)
-			}
-		}
-
-	}
-}
-
-func negmax(n, max int) int {
-	if n < 0 {
-		n = max + n
-		if n < 0 {
-			n = 0
-		}
-	} else if n > max {
-		return max
-	}
-	return n
-}
-
-// ()
-func newScript(script gval.Evaluable) plainSelector {
-	return func(c context.Context, r, v interface{}) (interface{}, error) {
-		return script(currentContext(c, v), r)
+		return value{value: v}, nil
 	}
 }

--- a/var.go
+++ b/var.go
@@ -1,0 +1,70 @@
+package jsonpath
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/PaesslerAG/gval"
+)
+
+func variableSelector(path gval.Evaluables) gval.Evaluable {
+	return func(c context.Context, v interface{}) (interface{}, error) {
+		for _, key := range path {
+			switch o := v.(type) {
+			case []interface{}:
+				i, err := key.EvalInt(c, v)
+				if err != nil {
+					return nil, fmt.Errorf("could not select value, invalid key: %s", err)
+				}
+				if i < 0 || i >= len(o) {
+					return nil, fmt.Errorf("index %d out of bounds", i)
+				}
+
+				v = o[i]
+			case map[string]interface{}:
+				k, err := key.EvalString(c, v)
+				if err != nil {
+					return nil, fmt.Errorf("could not select value, invalid key: %s", err)
+				}
+
+				r, ok := o[k]
+				if !ok {
+					return nil, fmt.Errorf("unknown key %s", k)
+				}
+
+				v = r
+			default:
+				return nil, fmt.Errorf("unsupported value type %T for select, expected map[string]interface{} or []interface{}", o)
+			}
+		}
+
+		return v, nil
+	}
+}
+
+func VariableSelector() func(path gval.Evaluables) gval.Evaluable {
+	return variableSelector
+}
+
+type variableGetter struct {
+	p *gval.Parser
+}
+
+func (vg variableGetter) ForEvaluables(c context.Context, keys gval.Evaluables, parameter interface{}) (interface{}, error) {
+	return vg.p.Var(keys...)(c, parameter)
+}
+
+func (vg variableGetter) ForConst(c context.Context, keys []interface{}, parameter interface{}) (interface{}, error) {
+	var eks gval.Evaluables
+	switch len(keys) {
+	case 1:
+		eks = gval.Evaluables{vg.p.Const(keys[0])}
+	default:
+		eks = make(gval.Evaluables, len(keys))
+		for i, k := range keys {
+			eks[i] = vg.p.Const(k)
+		}
+	}
+
+	return vg.ForEvaluables(c, eks, parameter)
+}

--- a/var.go
+++ b/var.go
@@ -3,68 +3,307 @@ package jsonpath
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
 
 	"github.com/PaesslerAG/gval"
 )
 
-func variableSelector(path gval.Evaluables) gval.Evaluable {
-	return func(c context.Context, v interface{}) (interface{}, error) {
-		for _, key := range path {
-			switch o := v.(type) {
-			case []interface{}:
-				i, err := key.EvalInt(c, v)
-				if err != nil {
-					return nil, fmt.Errorf("could not select value, invalid key: %s", err)
-				}
-				if i < 0 || i >= len(o) {
-					return nil, fmt.Errorf("index %d out of bounds", i)
-				}
+type variableWildcard struct{}
 
-				v = o[i]
-			case map[string]interface{}:
-				k, err := key.EvalString(c, v)
-				if err != nil {
-					return nil, fmt.Errorf("could not select value, invalid key: %s", err)
-				}
+type variableRecursiveDescent struct{}
 
-				r, ok := o[k]
-				if !ok {
-					return nil, fmt.Errorf("unknown key %s", k)
-				}
+type variableRange struct {
+	Min, Max, Step int
+}
 
-				v = r
-			default:
-				return nil, fmt.Errorf("unsupported value type %T for select, expected map[string]interface{} or []interface{}", o)
+type variableChild struct {
+	Key interface{}
+}
+
+type VariableVisitor interface {
+	VisitWildcard(ctx context.Context, parameter interface{}, next func(context.Context, []PathValue) error) error
+	VisitRecursiveDescent(ctx context.Context, parameter interface{}, next func(context.Context, []PathValue) error) error
+	VisitRange(ctx context.Context, parameter interface{}, min, max, step int, next func(context.Context, []PathValue) error) error
+	VisitChild(ctx context.Context, parameter interface{}, key interface{}, next func(context.Context, PathValue) error) error
+}
+
+type VariableVisitorFuncs struct {
+	VisitWildcardFunc         func(ctx context.Context, parameter interface{}, next func(context.Context, []PathValue) error) error
+	VisitRecursiveDescentFunc func(ctx context.Context, parameter interface{}, next func(context.Context, []PathValue) error) error
+	VisitRangeFunc            func(ctx context.Context, parameter interface{}, min, max, step int, next func(context.Context, []PathValue) error) error
+	VisitChildFunc            func(ctx context.Context, parameter interface{}, key interface{}, next func(context.Context, PathValue) error) error
+}
+
+var _ VariableVisitor = VariableVisitorFuncs{}
+
+func (vf VariableVisitorFuncs) VisitWildcard(c context.Context, v interface{}, next func(context.Context, []PathValue) error) error {
+	if vf.VisitWildcardFunc != nil {
+		return vf.VisitWildcardFunc(c, v, next)
+	}
+
+	var items []PathValue
+
+	appender := func(c context.Context, kv PathValue) error {
+		items = append(items, kv)
+		return nil
+	}
+
+	switch vt := v.(type) {
+	case []interface{}:
+		for i := range vt {
+			if err := vf.VisitChild(c, v, i, appender); err != nil {
+				return fmt.Errorf("could not parse index %d: %v", i, err)
 			}
 		}
-
-		return v, nil
-	}
-}
-
-func VariableSelector() func(path gval.Evaluables) gval.Evaluable {
-	return variableSelector
-}
-
-type variableGetter struct {
-	p *gval.Parser
-}
-
-func (vg variableGetter) ForEvaluables(c context.Context, keys gval.Evaluables, parameter interface{}) (interface{}, error) {
-	return vg.p.Var(keys...)(c, parameter)
-}
-
-func (vg variableGetter) ForConst(c context.Context, keys []interface{}, parameter interface{}) (interface{}, error) {
-	var eks gval.Evaluables
-	switch len(keys) {
-	case 1:
-		eks = gval.Evaluables{vg.p.Const(keys[0])}
-	default:
-		eks = make(gval.Evaluables, len(keys))
-		for i, k := range keys {
-			eks[i] = vg.p.Const(k)
+	case map[string]interface{}:
+		for k := range vt {
+			if err := vf.VisitChild(c, v, k, appender); err != nil {
+				return fmt.Errorf("could not parse key %q: %v", k, err)
+			}
 		}
 	}
 
-	return vg.ForEvaluables(c, eks, parameter)
+	return next(c, items)
+}
+
+func (vf VariableVisitorFuncs) VisitRecursiveDescent(c context.Context, v interface{}, next func(context.Context, []PathValue) error) error {
+	if vf.VisitRecursiveDescentFunc != nil {
+		return vf.VisitRecursiveDescentFunc(c, v, next)
+	}
+
+	items := []PathValue{
+		{Value: v},
+	}
+
+	var appender func(prefix ...string) func(context.Context, []PathValue) error
+	appender = func(prefix ...string) func(context.Context, []PathValue) error {
+		return func(c context.Context, vs []PathValue) error {
+			for _, v := range vs {
+				item := PathValue{
+					Path:  append(append([]string{}, prefix...), v.Path...),
+					Value: v.Value,
+				}
+
+				items = append(items, item)
+				if err := vf.VisitWildcard(c, v.Value, appender(item.Path...)); err != nil {
+					return fmt.Errorf("error resolving path %q: %v", strings.Join(v.Path, "."), err)
+				}
+			}
+
+			return nil
+		}
+	}
+	vf.VisitWildcard(c, v, appender())
+
+	return next(c, items)
+}
+
+func (vf VariableVisitorFuncs) VisitRange(c context.Context, v interface{}, min, max, step int, next func(context.Context, []PathValue) error) error {
+	if vf.VisitRangeFunc != nil {
+		return vf.VisitRangeFunc(c, v, min, max, step, next)
+	}
+
+	if min > max {
+		return nil
+	}
+
+	var items []PathValue
+
+	switch vt := v.(type) {
+	case []interface{}:
+		n := len(vt)
+		min = negmax(min, n)
+		max = negmax(max, n)
+	case map[string]interface{}:
+		// Ranging over a map is explicitly not supported.
+		return next(c, items)
+	default:
+		// Otherwise we hope the variable selector can do its job.
+	}
+
+	if step == 0 {
+		step = 1
+	}
+
+	appender := func(c context.Context, kv PathValue) error {
+		items = append(items, kv)
+		return nil
+	}
+
+	if step > 0 {
+		for i := min; i < max; i += step {
+			if err := vf.VisitChild(c, v, i, appender); err != nil {
+				return fmt.Errorf("could not parse index %d: %v", i, err)
+			}
+		}
+	} else {
+		for i := max - 1; i >= min; i += step {
+			if err := vf.VisitChild(c, v, i, appender); err != nil {
+				return fmt.Errorf("could not parse index %d: %v", i, err)
+			}
+		}
+	}
+
+	return next(c, items)
+}
+
+func negmax(n, max int) int {
+	if n < 0 {
+		n = max + n
+		if n < 0 {
+			n = 0
+		}
+	} else if n > max {
+		return max
+	}
+	return n
+}
+
+func (vf VariableVisitorFuncs) VisitChild(c context.Context, v interface{}, key interface{}, next func(context.Context, PathValue) error) error {
+	if vf.VisitChildFunc != nil {
+		return vf.VisitChildFunc(c, v, key, next)
+	}
+
+	var kv PathValue
+
+	switch vt := v.(type) {
+	case []interface{}:
+		var i int
+		switch kt := key.(type) {
+		case string:
+			ki, err := strconv.ParseInt(kt, 10, 32)
+			if err != nil {
+				return fmt.Errorf("unexpected string index %q for slice, must be convertible to int: %v", kt, err)
+			}
+
+			i = int(ki)
+		case int, int8, int16, int32, int64:
+			i = int(reflect.ValueOf(kt).Int())
+		case uint, uint8, uint16, uint32, uint64:
+			i = int(reflect.ValueOf(kt).Uint())
+		case float32, float64:
+			i = int(reflect.ValueOf(kt).Float())
+		default:
+			return fmt.Errorf("unexpected index type %T for slice", kt)
+		}
+
+		if i < 0 || i >= len(vt) {
+			return fmt.Errorf("index %d out of bounds", i)
+		}
+
+		kv.Path = []string{strconv.Itoa(i)}
+		kv.Value = vt[i]
+	case map[string]interface{}:
+		var k string
+		switch kt := key.(type) {
+		case string:
+			k = kt
+		case int, int8, int16, int32, int64:
+			k = strconv.FormatInt(reflect.ValueOf(kt).Int(), 64)
+		case uint, uint8, uint16, uint32, uint64:
+			k = strconv.FormatUint(reflect.ValueOf(kt).Uint(), 64)
+		case float32, float64:
+			k = strconv.FormatFloat(reflect.ValueOf(kt).Float(), 'f', -1, 64)
+		default:
+			return fmt.Errorf("unexpected key type %T for map", kt)
+		}
+
+		r, ok := vt[k]
+		if !ok {
+			return fmt.Errorf("unknown key %s", k)
+		}
+
+		kv.Path = []string{k}
+		kv.Value = r
+	default:
+		return fmt.Errorf("unsupported value type %T for select, expected map[string]interface{} or []interface{}", v)
+	}
+
+	return next(c, kv)
+}
+
+func VariableSelector(visitor VariableVisitor) func(path gval.Evaluables) gval.Evaluable {
+	return func(path gval.Evaluables) gval.Evaluable {
+		return func(c context.Context, v interface{}) (r interface{}, err error) {
+			var next func(c context.Context, rest gval.Evaluables, v interface{}) (values, bool, error)
+			next = func(c context.Context, rest gval.Evaluables, v interface{}) (values, bool, error) {
+				if len(rest) == 0 {
+					return nil, false, nil
+				}
+
+				t, err := rest[0](c, v)
+				if err != nil {
+					return nil, false, err
+				}
+
+				var r values
+				combine := func(c context.Context, vs values) error {
+					vs, err := vs.flatMap(func(v value) (values, error) {
+						r, ok, err := next(c, rest[1:], v.value)
+						if err != nil {
+							return nil, err
+						} else if !ok {
+							return v, nil
+						}
+
+						return v.prefix(r), nil
+					})
+					if err != nil {
+						return err
+					}
+
+					vs.concat(&r)
+					return nil
+				}
+
+				switch tt := t.(type) {
+				case variableWildcard:
+					err = visitor.VisitWildcard(c, v, func(c context.Context, pvs []PathValue) error {
+						return combine(c, pathValueSlice(pvs))
+					})
+				case variableRecursiveDescent:
+					err = visitor.VisitRecursiveDescent(c, v, func(c context.Context, pvs []PathValue) error {
+						return combine(c, pathValueSlice(pvs))
+					})
+				case variableRange:
+					err = visitor.VisitRange(c, v, tt.Min, tt.Max, tt.Step, func(c context.Context, pvs []PathValue) error {
+						return combine(c, pathValueSlice(pvs))
+					})
+				case variableChild:
+					err = visitor.VisitChild(c, v, tt.Key, func(c context.Context, pv PathValue) error {
+						return combine(c, value{wildcards: [][]string{pv.Path}, value: pv.Value})
+					})
+				default:
+					err = fmt.Errorf("unknown variable type %T", t)
+				}
+				return r, err == nil, err
+			}
+			r, _, err = next(c, path, v)
+			return
+		}
+	}
+}
+
+func pathValueSlice(pvs []PathValue) valueSlice {
+	vs := make(valueSlice, len(pvs))
+	for i, pv := range pvs {
+		vs[i] = value{wildcards: [][]string{pv.Path}, value: pv.Value}
+	}
+	return vs
+}
+
+func ChildVariableSelector(fn func(ctx context.Context, parameter interface{}, key interface{}, next func(context.Context, PathValue) error) error) func(path gval.Evaluables) gval.Evaluable {
+	return VariableSelector(VariableVisitorFuncs{
+		VisitChildFunc: fn,
+	})
+}
+
+func DefaultVariableVisitor() VariableVisitor {
+	return VariableVisitorFuncs{}
+}
+
+func DefaultVariableSelector() func(path gval.Evaluables) gval.Evaluable {
+	return VariableSelector(DefaultVariableVisitor())
 }


### PR DESCRIPTION
Hello!

Thank you for writing this library! The extensibility is _very_ impressive. We're looking into using it in one of our projects and it would be helpful to be able to do some data sanitization before a key is used. I found `VariableSelector` in Gval, but this library didn't support it, so I attempted to add it here.

I think I addressed most every case where someone would want to inject custom behavior, but I'm more than happy to make any revisions or suggestions you might like.

I also exposed `parseRootPath` as a public function because we want to support `kubectl`-style JSONPath "templates", which look like `{ .foo.bar }` instead of `$.foo.bar` (but are otherwise identical).

Thanks again!