### PR TITLE
bracket notation fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/PaesslerAG/jsonpath
 
-require github.com/PaesslerAG/gval v1
+go 1.15
+
+require github.com/PaesslerAG/gval v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,5 @@
-github.com/PaesslerAG/gval v0.1.0 h1:XxyoMWvLhTNiRcXg2dsG0LaOMcRTh22doPMWYLAe528=
-github.com/PaesslerAG/gval v0.1.0/go.mod h1:jjpVgM2F5GvUIHLM66Z4B4tyojnCW8kh/QY68RpHucQ=
+github.com/PaesslerAG/gval v1.2.2 h1:Y7iBzhgE09IGTt5QgGQ2IdaYYYOU134YGHBThD+wm9E=
+github.com/PaesslerAG/gval v1.2.2/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbVR+C6xac=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -48,10 +48,16 @@ func TestJsonPath(t *testing.T) {
 			want: "hey",
 		},
 		{
-			name:    "negativ select array",
-			path:    "$[-1]",
-			data:    `[7, "hey"]`,
-			wantErr: true,
+			name: "negativ select array",
+			path: "$[-1]",
+			data: `[7, "hey"]`,
+			want: "hey",
+		},
+		{
+			name: "negativ select on short array",
+			path: "$[-2]",
+			data: `[7]`,
+			want: nil,
 		},
 		{
 			name: "simple select object",
@@ -60,10 +66,10 @@ func TestJsonPath(t *testing.T) {
 			want: "aa",
 		},
 		{
-			name:    "simple select out of bounds",
-			path:    "$[1]",
-			data:    `["hey"]`,
-			wantErr: true,
+			name: "simple select out of bounds",
+			path: "$[1]",
+			data: `["hey"]`,
+			want: nil,
 		},
 		{
 			name:    "simple select unknown key",
@@ -448,7 +454,7 @@ func TestJsonPath(t *testing.T) {
 func (tt jsonpathTest) test(t *testing.T) {
 	get, err := tt.lang.NewEvaluable(tt.path)
 	if (err != nil) != tt.wantParseErr {
-		t.Fatalf("New() error = %v, wantErr %v", err, tt.wantErr)
+		t.Fatalf("[%s]: New() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 	}
 	if tt.wantParseErr {
 		return
@@ -456,20 +462,20 @@ func (tt jsonpathTest) test(t *testing.T) {
 	var v interface{}
 	err = json.Unmarshal([]byte(tt.data), &v)
 	if err != nil {
-		t.Fatalf("could not parse json input: %v", err)
+		t.Fatalf("[%s]: could not parse json input: %v", tt.name, err)
 	}
 	got, err := get(context.Background(), v)
 
 	if tt.wantErr {
 		if err == nil {
-			t.Errorf("expected error %v but got %v", tt.wantErr, got)
+			t.Errorf("[%s]: expected error %v but got %v", tt.name, tt.wantErr, got)
 			return
 		}
 		return
 	}
 
 	if err != nil {
-		t.Errorf("JSONPath(%s) error = %v", tt.path, err)
+		t.Errorf("[%s]: JSONPath(%s) error = %v", tt.name, tt.path, err)
 		return
 	}
 
@@ -478,7 +484,7 @@ func (tt jsonpathTest) test(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(got, tt.want) {
-		t.Fatalf("expected %v, but got %v", tt.want, got)
+		t.Fatalf("[%s]: expected %v, but got %v", tt.name, tt.want, got)
 	}
 }
 

--- a/selector.go
+++ b/selector.go
@@ -8,13 +8,13 @@ import (
 	"github.com/PaesslerAG/gval"
 )
 
-//plainSelector evaluate exactly one result
+// plainSelector evaluate exactly one result
 type plainSelector func(c context.Context, r, v interface{}) (interface{}, error)
 
-//ambiguousSelector evaluate wildcard
+// ambiguousSelector evaluate wildcard
 type ambiguousSelector func(c context.Context, r, v interface{}, match ambiguousMatcher)
 
-//@
+// @
 func currentElementSelector() plainSelector {
 	return func(c context.Context, r, v interface{}) (interface{}, error) {
 		return c.Value(currentElement{}), nil
@@ -27,7 +27,7 @@ func currentContext(c context.Context, v interface{}) context.Context {
 	return context.WithValue(c, currentElement{}, v)
 }
 
-//.x, [x]
+// .x, [x]
 func directSelector(key gval.Evaluable) plainSelector {
 	return func(c context.Context, r, v interface{}) (interface{}, error) {
 
@@ -71,10 +71,14 @@ func selectValue(c context.Context, key gval.Evaluable, r, v interface{}) (value
 		if err != nil {
 			return nil, "", fmt.Errorf("could not select value, invalid key: %s", err)
 		}
-		if i < 0 || i >= len(o) {
-			return nil, "", fmt.Errorf("index %d out of bounds", i)
+		p := i
+		if i < 0 {
+			p = len(o) + i
 		}
-		return o[i], strconv.Itoa(i), nil
+		if p < 0 || p >= len(o) {
+			return nil, strconv.Itoa(i), nil
+		}
+		return o[p], strconv.Itoa(i), nil
 	case map[string]interface{}:
 		k, err := key.EvalString(c, r)
 		if err != nil {
@@ -91,7 +95,7 @@ func selectValue(c context.Context, key gval.Evaluable, r, v interface{}) (value
 	}
 }
 
-//..
+// ..
 func mapperSelector() ambiguousSelector {
 	return mapper
 }
@@ -120,7 +124,7 @@ func visitAll(v interface{}, visit func(key string, v interface{})) {
 
 }
 
-//[? ]
+// [? ]
 func filterSelector(filter gval.Evaluable) ambiguousSelector {
 	return func(c context.Context, r, v interface{}, match ambiguousMatcher) {
 		visitAll(v, func(wildcard string, v interface{}) {
@@ -135,7 +139,7 @@ func filterSelector(filter gval.Evaluable) ambiguousSelector {
 	}
 }
 
-//[::]
+// [::]
 func rangeSelector(min, max, step gval.Evaluable) ambiguousSelector {
 	return func(c context.Context, r, v interface{}, match ambiguousMatcher) {
 		cs, ok := v.([]interface{})


### PR DESCRIPTION
Changes:

- Updated  "github.com/PaesslerAG/gval" to v1.2.2
- Set GO version to 1.15, same version used in "github.com/PaesslerAG/gval"
- fixed the following scenarios according to [JSONPath Comparison](https://cburgmer.github.io/json-path-comparison/):

[Bracket notation with number -1](https://cburgmer.github.io/json-path-comparison/results/bracket_notation_with_number_-1.html)
```
test: negativ select array
path: $[-1]
data: [7, "hey"]
result: "hey"
```

[Bracket notation with number -1 on empty array](https://cburgmer.github.io/json-path-comparison/results/bracket_notation_with_number_-1_on_empty_array.html)
```
test: negativ select on short array
path: $[-2]
data: [7]
result: nil
```

[Bracket notation with number on short array](https://cburgmer.github.io/json-path-comparison/results/bracket_notation_with_number_on_short_array.html)
```
test: simple select out of bounds
path: $[1]
data: ["hey"]
result: nil
```
