### PR TITLE
Fix a broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ JSONPath
 [![Godoc](https://godoc.org/github.com/PaesslerAG/jsonpath?status.png)](https://godoc.org/github.com/PaesslerAG/jsonpath)
 
 JSONPath is a complete implementation of [http://goessner.net/articles/JsonPath/](http://goessner.net/articles/JsonPath/).
-JSONPath can be combined with a script language. In many web samples it's combined with javascript. This framework comes without a script language but can be easily extended with one. See [example](https://godoc.org/github.com/PaesslerAG/jsonpath#example-package--Gval).
+JSONPath can be combined with a script language. In many web samples it's combined with javascript. This framework comes without a script language but can be easily extended with one. See [example](https://godoc.org/github.com/PaesslerAG/jsonpath#example-package-Gval).
 
 It is based on [Gval](https://github.com/PaesslerAG/gval) and can be combined with the modular expression languages based on gval.
 So for script features like multiply, length, regex or many more take a look at the documentation in the [GoDoc](https://godoc.org/github.com/PaesslerAG/jsonpath).


### PR DESCRIPTION
Fix the broken example link of using Gval instruction in the README.md file.